### PR TITLE
refactoring getComponentTemplate

### DIFF
--- a/lib/template-factory.js
+++ b/lib/template-factory.js
@@ -3,17 +3,7 @@
 const componentTemplate = require ('../templates/component');
 
 const getComponentTemplate = (componentName, includedMethods) => {
-    let willMount = includedMethods.componentWillMount;
-    let willReceiveProps = includedMethods.componentWillReceiveProps;
-    let shouldUpdate = includedMethods.shouldComponentUpdate;
-    let willUpdate = includedMethods.componentWillUpdate;
-    let didMount = includedMethods.componentDidMount;
-    let didUpdate = includedMethods.componentDidUpdate;
-    let willUnmount = includedMethods.componentWillUnmount;
-    let didCatch = includedMethods.componentDidCatch;
-
-    return componentTemplate(componentName, willMount, willReceiveProps, shouldUpdate, 
-        willUpdate, didMount, didUpdate, willUnmount, didCatch);
+    return componentTemplate(componentName, includedMethods);
 }
 
 module.exports = getComponentTemplate;

--- a/templates/component.js
+++ b/templates/component.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const componentTemplate = (name, willMount, willReceiveProps, shouldUpdate, willUpdate, didMount, didUpdate, willUnmount, didCatch) => {
+const componentTemplate = (name, includedMethods) => {
     let template =
 
 `import React, { Component } from 'react';
@@ -16,28 +16,28 @@ class ${name} extends Component {
     }
 `;
 
-if (willMount)
+if (includedMethods.componentWillMount)
     template +=
 `
     componentWillMount() {
     }
 `;
 
-if (willReceiveProps)
+if (includedMethods.componentWillReceiveProps)
     template +=
 `
     componentWillReceiveProps(nextProps){
     }
 `;
 
-if (shouldUpdate)
+if (includedMethods.shouldComponentUpdate)
     template +=
 `
     shouldComponentUpdate(nextProps, nextState){
     }
 `;
 
-if (willUpdate)
+if (includedMethods.componentWillUpdate)
     template +=
 `
     componentWillUpdate(nextProps, nextState){
@@ -55,28 +55,28 @@ template +=
     }
 `;
 
-if (didMount)
+if (includedMethods.componentDidMount)
     template +=
 `
     componentDidMount() {
     }
 `;
 
-if (didUpdate)
+if (includedMethods.componentDidUpdate)
     template +=
 `
     componentDidUpdate(prevProps, prevState){
     }
 `;
 
-if (willUnmount)
+if (includedMethods.componentWillUnmount)
     template +=
 `
     componentWillUnmount() {
     }
 `;
 
-if (didCatch)
+if (includedMethods.componentDidCatch)
     template +=
 `
     componentDidCatch(error, info){


### PR DESCRIPTION
I refactored the `getComponentTemplate`. It now passes in the `includedMethods` object directly to the `componentTemplate` function instead of initializing a new variable for each lifecycle method.