### PR TITLE
Fix Helper

### DIFF
--- a/bin/helpers.js
+++ b/bin/helpers.js
@@ -3,7 +3,7 @@
 const Configstore = require('configstore');
 const conf = new Configstore('napp-config');
 
-const changeAllSettings = (store=conf, bool) => {
+const changeAllSettings = (bool, store=conf) => {
     store.set({
         componentWillMount: bool,
         componentWillReceiveProps: bool,

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -32,7 +32,7 @@ describe('changeAllSettings', () => {
         };
 
         expect(conf.all).toEqual(settings);
-        changeAllSettings(conf, true);
+        changeAllSettings(true, conf);
         expect(conf.all).toEqual(expectedSettings);
         settings = expectedSettings;
     });
@@ -50,7 +50,7 @@ describe('changeAllSettings', () => {
         };
 
         expect(conf.all).toEqual(settings);
-        changeAllSettings(conf, false);
+        changeAllSettings(false, conf);
         expect(conf.all).toEqual(expectedSettings);
     });
 });


### PR DESCRIPTION
When the arguments passed to the `changeAllSettings` method was changed it broke the `setup` command. This PR compensates for the change and fixes the issue.